### PR TITLE
Fix compiler error on FreeBSD

### DIFF
--- a/tkrzw_str_util.cc
+++ b/tkrzw_str_util.cc
@@ -18,7 +18,7 @@
 
 namespace tkrzw {
 
-#if defined(_SYS_POSIX_) && !defined(_TKRZW_STDONLY)
+#if defined(_SYS_POSIX_) && !defined(_TKRZW_STDONLY) && !defined(_SYS_FREEBSD_)
 
 inline void* tkrzw_memmem(const void* haystack, size_t haystacklen,
                           const void* needle, size_t needlelen) {


### PR DESCRIPTION
On FreeBSD <cstring>/<string.h> does not make visible memmem() when compiling *ISO*_SOURCE or *POSIX*_SOURCE.
Quick fix is using the internal implementation, working on the config stuff might be better.
A.