### PR TITLE
Removing -D_POSIX_C_SOURCE=999999L made memmem() visible on FreeBSD

### DIFF
--- a/tkrzw_str_util.cc
+++ b/tkrzw_str_util.cc
@@ -18,7 +18,7 @@
 
 namespace tkrzw {
 
-#if defined(_SYS_POSIX_) && !defined(_TKRZW_STDONLY) && !defined(_SYS_FREEBSD_)
+#if defined(_SYS_POSIX_) && !defined(_TKRZW_STDONLY)
 
 inline void* tkrzw_memmem(const void* haystack, size_t haystacklen,
                           const void* needle, size_t needlelen) {


### PR DESCRIPTION
I am reverting my previous patch as removing -D_POSIX_C_SOURCE=999999L (which is necessary to compile on LLVM) makes memmem() visible again on FreeBSD.
As on FreeBSD compiling libraries with GCC is becoming a link-mangling nightmare at this point, in my humble opinion LLVM is the way to go.
