### PR TITLE
Add GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,6 +20,7 @@ jobs:
            configure_args: --enable-profile
          - description: Address Sanitition
            configure_args: --enable-sanitize-address
+           continue_on_error: true
          - description: Thread Sanitition
            configure_args: --enable-sanitize-thread
            continue_on_error: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,7 +53,7 @@ jobs:
       contents: read
 
     steps:
-      - name: "Install additional packages using pkg"
+      - name: "Install additional packages using apt"
         if: ${{ matrix.apt_install }}
         run: |
           sudo apt update

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,8 +28,6 @@ jobs:
            configure_args: --disable-opt
          - description: Native Optimization
            configure_args: --enable-opt-native
-         - description: Native Optimization
-           configure_args: --enable-opt-native
          - description: Static Library
            configure_args: --enable-static
          - description: zlib

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,7 @@ jobs:
            configure_args: --enable-sanitize-address
          - description: Thread Sanitition
            configure_args: --enable-sanitize-thread
+           continue_on_error: true
          - description: No Optimization
            configure_args: --disable-opt
          - description: Native Optimization
@@ -77,6 +78,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
       
       - name: Test
+        continue-on-error: ${{ matrix.continue_on_error }}
         run: |
           make check
         working-directory: ${{ github.workspace }}/build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,6 @@ jobs:
            configure_args: --enable-profile
          - description: Address Sanitition
            configure_args: --enable-sanitize-address
-           continue_on_error: true
          - description: Thread Sanitition
            configure_args: --enable-sanitize-thread
            continue_on_error: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,114 @@
+name: Build and Test
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  autotools:
+    strategy:
+      matrix:
+        include:
+         - description: Default
+         - description: LLVM
+           cc: clang
+           cxx: clang++
+         - description: Debug
+           configure_args: --enable-debug
+         - description: Profiling
+           configure_args: --enable-profile
+         - description: Address Sanitition
+           configure_args: --enable-sanitize-address
+         - description: Thread Sanitition
+           configure_args: --enable-sanitize-thread
+         - description: No Optimization
+           configure_args: --disable-opt
+         - description: Native Optimization
+           configure_args: --enable-opt-native
+         - description: Native Optimization
+           configure_args: --enable-opt-native
+         - description: Static Library
+           configure_args: --enable-static
+         - description: zlib
+           configure_args: --enable-zlib
+           apt_install: zlib1g-dev
+         - description: zstd
+           configure_args: --enable-zstd
+           apt_install: libzstd-dev
+         - description: lz4
+           configure_args: --enable-lz4
+           apt_install: liblz4-dev 
+         - description: lzma
+           configure_args: --enable-lzma
+           apt_install: liblzma-dev
+         - description: most features
+           configure_args: --enable-most-features
+           apt_install: zlib1g-dev libzstd-dev liblz4-dev liblzma-dev
+
+    name: autoconf workflow using ${{ matrix.description }}
+    
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Install additional packages using pkg"
+        if: ${{ matrix.apt_install }}
+        run: |
+          sudo apt update
+          sudo apt install -y ${{ matrix.apt_install }}
+      
+      - name: "Clone Repository"
+        uses: actions/checkout@v4
+      
+      - name: Create build directory
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/build
+      
+      - name: Build
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          ${GITHUB_WORKSPACE}/configure ${{ matrix.configure_args }} --prefix ${RUNNER_TEMP}/install-here
+          make
+        working-directory: ${{ github.workspace }}/build
+      
+      - name: Test
+        run: |
+          make check
+        working-directory: ${{ github.workspace }}/build
+        
+      - name: Install
+        run: |
+          make install
+          find ${RUNNER_TEMP}/install-here
+        working-directory: ${{ github.workspace }}/build
+
+  nmake:
+    name: "nmake workflow"
+    
+    runs-on: windows-latest
+    
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Clone Repository"
+        uses: actions/checkout@v4
+
+      - name: "Enter-VsDevShell"
+        uses: ilammy/msvc-dev-cmd@v1
+          
+      - name: Build
+        run: |
+          $vcpath=(Get-Item (& "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -requires "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" -find VC\Tools\MSVC\*\lib\x64\libcpmt.lib)[0]).Directory.Parent.Parent.FullName
+          nmake -f ${env:GITHUB_WORKSPACE}/VCMakefile "VCPATH=${vcpath}"
+        working-directory: ${{ github.workspace }}
+          
+      - name: Test
+        run: |
+          nmake -f ${env:GITHUB_WORKSPACE}/VCMakefile check
+        working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Add a Github Actions Workflow that covers all "use stories" I identified by analyzing [configure.in](https://github.com/estraier/tkrzw/blob/409a57bf7507a4079d0519bc4a023da8ab79e132/configure.in) and [VCMakefile](https://github.com/estraier/tkrzw/blob/409a57bf7507a4079d0519bc4a023da8ab79e132/VCMakefile), and triggers on pushes as well as pull requests to the master branch.

[Thread Sanitation](https://github.com/SchaichAlonso/tkrzw-gha/blob/45b825822795b480c468adfb29134fb4bcfde3a1/.github/workflows/build_and_test.yml#L26) ~and [Address Sanitation](https://github.com/SchaichAlonso/tkrzw-gha/blob/45b825822795b480c468adfb29134fb4bcfde3a1/.github/workflows/build_and_test.yml#L23) are both~ configured to [ignore test results](https://github.com/SchaichAlonso/tkrzw-gha/blob/45b825822795b480c468adfb29134fb4bcfde3a1/.github/workflows/build_and_test.yml#L80), as they're currently both detecting errors on the `ubuntu-latest` runners.

Once the sanitizer bugs are fixed, the actions workflow should be adapted to no longer ignore failures in those tests.

Also, [the way the msvc installation is detected](https://github.com/SchaichAlonso/tkrzw-gha/blob/45b825822795b480c468adfb29134fb4bcfde3a1/.github/workflows/build_and_test.yml#L108) in order to override the hardcoded path in [VCMakefile:6](https://github.com/estraier/tkrzw/blob/409a57bf7507a4079d0519bc4a023da8ab79e132/VCMakefile#L6) might not work well on systems that have multiple MSVC versions installed.

Fixes: #53 